### PR TITLE
0008 - scriptworker *script monorepo

### DIFF
--- a/rfcs/0008-scriptworker-script-monorepo.md
+++ b/rfcs/0008-scriptworker-script-monorepo.md
@@ -46,8 +46,10 @@ We need to have ways of excluding or special-casing \*scripts. `balrogscript` is
 
 We should version each module or script like we do currently: semver. Libraries (e.g., scriptworker-client) will bump major versions every time they make a non-backwards-compatible change. The \*scripts will bump their major versions when they make a task- or puppet- (runtime- or deployment-) backwards-incompatible change.
 
+Initially, we will push docker releases via pushes to production branches. In the future, we will port scriptworker-scripts to taskgraph, and take advantages of the features it has (only build what changes; Chain of Trust verification; using artifacts and indexes from previously run tasks).
+
 # Open Questions
 
 # Implementation
 
-I'm playing with an experimental monorepo at [escapewindow/scriptworker-scripts](https://github.com/escapewindow/scriptworker-scripts). We can go with this, make adjustments, or completely revisit, depending on what people think.
+We have a monorepo at [mozilla-releng/scriptworker-scripts](https://github.com/mozilla-releng/scriptworker-scripts), already using Taskcluster for automation. The scripts are yet to be unified in terms of behavior, using `scriptworker_client`, using taskgraph, etc., but we will do that over time.

--- a/rfcs/0008-scriptworker-script-monorepo.md
+++ b/rfcs/0008-scriptworker-script-monorepo.md
@@ -32,6 +32,7 @@ We are still able to make exceptions for behavior in \*scripts when needed. For 
 
 # Details
 
+## Proposal 1
 We create a github repo, `mozilla-releng/scriptworker-scripts`. We move the code from `scriptworker.client` into a `scriptworker-client` subdirectory, with its own `setup.py`. Tests will go under each subdirectly, e.g. `scriptworker-client/tests/` or `signingscript/tests`. We can move each production-ready, releng-maintained \*script into the monorepo over time.
 
 Each \*script will have its own `setup.py`.
@@ -44,6 +45,19 @@ We can do things like pyup dependency pinning across the repo like we do with pu
 
 We need to have ways of excluding or special-casing \*scripts. `balrogscript` is py2; the upcoming `applescript` will be targeted towards running on mac hosts instead of deployed through kubernetes.
 
+## Proposal 2
+We gradually begin moving our \*scripts into the [release-services](https://github.com/mozilla/release-services) repo, as we nixify and prepare each one for deployment into GCP.
+
+Each \*script will still have its own `setup.py` and its own `tests/` subdirectory.
+
+Any change in shared behavior should still span all \*scripts as applicable.
+
+We need to adjust the release-services taskgraph and deployment story to also support \*script deployment processes and cadences. Most likely we need a way to easily release a subset of projects inside the repo, and exclude projects from the current services release cadence.
+
+Most likely our pinning will happen through nix.
+
+We need to have ways of excluding or special-casing \*scripts. `balrogscript` is py2; the upcoming `applescript` will be targeted towards running on mac hosts instead of deployed through kubernetes.
+
 # Open Questions
 
 We need a way to handle applescript and balrogscript differently from the rest of the \*scripts.
@@ -52,7 +66,7 @@ Do we call it mozilla-releng/scriptworker-scripts ?
 
 Specific details about directory layouts, tox.ini per subdirectory or top level?, pyup pinning standards? nix?, code coverage service?, but I imagine we will decide on something good, and have the capability of changing it in the future without having to touch 10+ repos for consistency.
 
-Do we combine all releng [python] repos into one?
+Do we go with option 1 or 2? (\*scripts living with \*services or no?)
 
 Versioning and tagging rules. Does Nix make this obsolete?
 

--- a/rfcs/0008-scriptworker-script-monorepo.md
+++ b/rfcs/0008-scriptworker-script-monorepo.md
@@ -48,11 +48,13 @@ We need to have ways of excluding or special-casing \*scripts. `balrogscript` is
 
 We need a way to handle applescript and balrogscript differently from the rest of the \*scripts.
 
-We haven't touched binary transparency in a long time; perhaps we should call this not-yet-production-ready and wait to move it?
-
 Do we call it mozilla-releng/scriptworker-scripts ?
 
 Specific details about directory layouts, tox.ini per subdirectory or top level?, pyup pinning standards? nix?, code coverage service?, but I imagine we will decide on something good, and have the capability of changing it in the future without having to touch 10+ repos for consistency.
+
+Do we combine all releng [python] repos into one?
+
+Versioning and tagging rules. Does Nix make this obsolete?
 
 # Implementation
 

--- a/rfcs/0008-scriptworker-script-monorepo.md
+++ b/rfcs/0008-scriptworker-script-monorepo.md
@@ -50,3 +50,4 @@ We should version each module or script like we do currently: semver. Libraries 
 
 # Implementation
 
+I'm playing with an experimental monorepo at [escapewindow/scriptworker-scripts](https://github.com/escapewindow/scriptworker-scripts). We can go with this, make adjustments, or completely revisit, depending on what people think.

--- a/rfcs/0008-scriptworker-script-monorepo.md
+++ b/rfcs/0008-scriptworker-script-monorepo.md
@@ -45,6 +45,16 @@ We can do things like pyup dependency pinning across the repo like we do with pu
 
 We need to have ways of excluding or special-casing \*scripts. `balrogscript` is py2; the upcoming `applescript` will be targeted towards running on mac hosts instead of deployed through kubernetes.
 
+Pluses:
+
+- the \*scripts have a lot in common, and will behave the same.
+- we can potentially create this monorepo sooner, and adjust behavior as we nixify each \*script and deploy to GCP instead of through puppet
+
+Concerns:
+
+- we'll have shared code+automation needs between release-services and \*scripts, e.g. papertrail logging and nix support.
+- we may end up moving the \*scripts a second time if it makes sense to share a repo with release-services in the future.
+
 ## Proposal 2
 We gradually begin moving our \*scripts into the [release-services](https://github.com/mozilla/release-services) repo, as we nixify and prepare each one for deployment into GCP.
 
@@ -57,6 +67,17 @@ We need to adjust the release-services taskgraph and deployment story to also su
 Most likely our pinning will happen through nix.
 
 We need to have ways of excluding or special-casing \*scripts. `balrogscript` is py2; the upcoming `applescript` will be targeted towards running on mac hosts instead of deployed through kubernetes.
+
+Pluses:
+
+- we can share code and automation between release-services and \*scripts, which will look more and more similar when we move to GCP
+- one place to make improvements across all of our microservices
+- a larger pool of people familiar with each workflow. `bus_factor++`
+
+Concerns:
+- we probably don't want to move the \*scripts in until they're ready for nix+docker+GCP, making this a longer term project
+- we'll need to adjust the release-services shared code, automation, and cadences to allow for similar-but-different \*script code+automation+cadence needs.
+- the `please` tool has some rough edges, which we'll want to address
 
 # Open Questions
 

--- a/rfcs/0008-scriptworker-script-monorepo.md
+++ b/rfcs/0008-scriptworker-script-monorepo.md
@@ -13,18 +13,18 @@ We have 10 \*scripts in puppet currently, and are looking at adding more. Curren
 This proves challenging for:
 
 * discoverability. If you want to find all of the scriptworker \*scripts, you can browse the mozilla-releng organization for any repos that seem to match the right naming scheme. As the number of repos increase, or if a \*script is outside the mozilla-releng org for any reason, it will get worse.
-* consistency in \*script behavior.
-* consistency in github automation.
-* consistency in \*script deployment.
-* making changes across \*scripts.
+* consistency in \*script behavior. Outside of recommended behaviors and the shared code in `scriptworker.client`, the separate repos lend themselves to divergence of behavior.
+* consistency in github automation. Similar to the \*script behavior, the travis+pyup+code coverage automation configurations have already diverged.
+* consistency in \*script deployment. With each maintainer defining their own behaviors, we've deployed some \*scripts to pypi, added towncrier to some.
+* making changes across \*scripts. We've had a few instances of this in recent memory, where someone has to create PRs across 10+ repos.
 
 Moving to a monorepo for \*scripts improves all of the above:
 
 * discoverability: if you find the monorepo, you've found all of the \*scripts.
 * consistency in \*script behavior: it's possible to inspect and modify \*scripts' behavior in a single place.
-* consistency in github automation:
-* consistency in \*script deployment:
-* making changes across \*scripts:
+* consistency in github automation: with a single `.travis.yml` and/or `.taskcluster.yml`, and a single repo to point other services at (e.g. code coverage, pyup).
+* consistency in \*script deployment: we're currently planning on converging on nix, but even nix-based solutions could diverge over 10+ repos. The monorepo allows us to configure them all from the same place.
+* making changes across \*scripts: even if we want to make a sweeping change, we could find the relevant scripts in the same repo.
 
 We are still able to make exceptions for behavior in \*scripts when needed. For example, we could have exceptions to allow balrogscript to run on py2, until we address that issue. We should be able to temporarily branch and/or keep a \*script on an older codebase (e.g. by not deploying the latest to production) if needed.
 

--- a/rfcs/0008-scriptworker-script-monorepo.md
+++ b/rfcs/0008-scriptworker-script-monorepo.md
@@ -1,0 +1,58 @@
+# RFC 0008 - Scriptworker \*script Monorepo
+* Comments: [#8](https://api.github.com/repos/mozilla-releng/releng-rfcs/issues/8)
+* Proposed by: @escapewindow
+
+# Summary
+
+We should put all of our releng-maintained production scriptworker \*scripts into a single repo, so we can improve discoverability, keep \*script behaviors consistent, and make it easier to make \*script-wide changes.
+
+## Motivation
+
+We have 10 \*scripts in puppet currently, and are looking at adding more. Currently that means we have 10 github repos, plus scriptworker itself for `scriptworker.client`, which most \*scripts import for shared behaviors.
+
+This proves challenging for:
+
+* discoverability. If you want to find all of the scriptworker \*scripts, you can browse the mozilla-releng organization for any repos that seem to match the right naming scheme. As the number of repos increase, or if a \*script is outside the mozilla-releng org for any reason, it will get worse.
+* consistency in \*script behavior.
+* consistency in github automation.
+* consistency in \*script deployment.
+* making changes across \*scripts.
+
+Moving to a monorepo for \*scripts improves all of the above:
+
+* discoverability: if you find the monorepo, you've found all of the \*scripts.
+* consistency in \*script behavior: it's possible to inspect and modify \*scripts' behavior in a single place.
+* consistency in github automation:
+* consistency in \*script deployment:
+* making changes across \*scripts:
+
+We are still able to make exceptions for behavior in \*scripts when needed. For example, we could have exceptions to allow balrogscript to run on py2, until we address that issue. We should be able to temporarily branch and/or keep a \*script on an older codebase (e.g. by not deploying the latest to production) if needed.
+
+(Coop tweeted a [thread about taskcluster going to a monorepo](https://mobile.twitter.com/ccooper/status/1081264280429871104). We have a similar situation: small code size, small team size, and we're also going to be handing off operational responsibilities to cloudops.)
+
+# Details
+
+We create a github repo, `mozilla-releng/scriptworker-scripts`. We move the code from `scriptworker.client` into a `scriptworker-client` subdirectory, with its own `setup.py`. Tests will go under each subdirectly, e.g. `scriptworker-client/tests/` or `signingscript/tests`. We can move each production-ready, releng-maintained \*script into the monorepo over time.
+
+Each \*script will have its own `setup.py`.
+
+Initially, we can cover automated testing via a `.travis.yml` that covers the entire repo, but this will be complex enough that we will want a `.taskcluster.yml` to test each \*script concurrently, and potentially build wheels and docker images in automation.
+
+Any change in shared behavior should span all \*scripts as applicable.
+
+We can do things like pyup dependency pinning across the repo like we do with puppet.
+
+We need to have ways of excluding or special-casing \*scripts. `balrogscript` is py2; the upcoming `applescript` will be targeted towards running on mac hosts instead of deployed through kubernetes.
+
+# Open Questions
+
+We need a way to handle applescript and balrogscript differently from the rest of the \*scripts.
+
+We haven't touched binary transparency in a long time; perhaps we should call this not-yet-production-ready and wait to move it?
+
+Do we call it mozilla-releng/scriptworker-scripts ?
+
+Specific details about directory layouts, tox.ini per subdirectory or top level?, pyup pinning standards? nix?, code coverage service?, but I imagine we will decide on something good, and have the capability of changing it in the future without having to touch 10+ repos for consistency.
+
+# Implementation
+

--- a/rfcs/0008-scriptworker-script-monorepo.md
+++ b/rfcs/0008-scriptworker-script-monorepo.md
@@ -32,7 +32,6 @@ We are still able to make exceptions for behavior in \*scripts when needed. For 
 
 # Details
 
-## Proposal 1
 We create a github repo, `mozilla-releng/scriptworker-scripts`. We move the code from `scriptworker.client` into a `scriptworker-client` subdirectory, with its own `setup.py`. Tests will go under each subdirectly, e.g. `scriptworker-client/tests/` or `signingscript/tests`. We can move each production-ready, releng-maintained \*script into the monorepo over time.
 
 Each \*script will have its own `setup.py`.
@@ -43,53 +42,11 @@ Any change in shared behavior should span all \*scripts as applicable.
 
 We can do things like pyup dependency pinning across the repo like we do with puppet.
 
-We need to have ways of excluding or special-casing \*scripts. `balrogscript` is py2; the upcoming `applescript` will be targeted towards running on mac hosts instead of deployed through kubernetes.
+We need to have ways of excluding or special-casing \*scripts. `balrogscript` is py2; the upcoming `iscript` will be targeted towards running on mac hosts instead of deployed through kubernetes.
 
-Pluses:
-
-- the \*scripts have a lot in common, and will behave the same.
-- we can potentially create this monorepo sooner, and adjust behavior as we nixify each \*script and deploy to GCP instead of through puppet
-
-Concerns:
-
-- we'll have shared code+automation needs between release-services and \*scripts, e.g. papertrail logging and nix support.
-- we may end up moving the \*scripts a second time if it makes sense to share a repo with release-services in the future.
-
-## Proposal 2
-We gradually begin moving our \*scripts into the [release-services](https://github.com/mozilla/release-services) repo, as we nixify and prepare each one for deployment into GCP.
-
-Each \*script will still have its own `setup.py` and its own `tests/` subdirectory.
-
-Any change in shared behavior should still span all \*scripts as applicable.
-
-We need to adjust the release-services taskgraph and deployment story to also support \*script deployment processes and cadences. Most likely we need a way to easily release a subset of projects inside the repo, and exclude projects from the current services release cadence.
-
-Most likely our pinning will happen through nix.
-
-We need to have ways of excluding or special-casing \*scripts. `balrogscript` is py2; the upcoming `applescript` will be targeted towards running on mac hosts instead of deployed through kubernetes.
-
-Pluses:
-
-- we can share code and automation between release-services and \*scripts, which will look more and more similar when we move to GCP
-- one place to make improvements across all of our microservices
-- a larger pool of people familiar with each workflow. `bus_factor++`
-
-Concerns:
-- we probably don't want to move the \*scripts in until they're ready for nix+docker+GCP, making this a longer term project
-- we'll need to adjust the release-services shared code, automation, and cadences to allow for similar-but-different \*script code+automation+cadence needs.
-- the `please` tool has some rough edges, which we'll want to address
+We should version each module or script like we do currently: semver. Libraries (e.g., scriptworker-client) will bump major versions every time they make a non-backwards-compatible change. The \*scripts will bump their major versions when they make a task- or puppet- (runtime- or deployment-) backwards-incompatible change.
 
 # Open Questions
-
-We need a way to handle applescript and balrogscript differently from the rest of the \*scripts.
-
-Do we call it mozilla-releng/scriptworker-scripts ?
-
-Specific details about directory layouts, tox.ini per subdirectory or top level?, pyup pinning standards? nix?, code coverage service?, but I imagine we will decide on something good, and have the capability of changing it in the future without having to touch 10+ repos for consistency.
-
-Do we go with option 1 or 2? (\*scripts living with \*services or no?)
-
-Versioning and tagging rules. Does Nix make this obsolete?
 
 # Implementation
 


### PR DESCRIPTION
We should put all of our releng-maintained production scriptworker *scripts into a single repo, so we can improve discoverability, keep \*script behaviors consistent, and make it easier to make *script-wide changes.
