### PR TITLE
Creates RFC for bumping script versions to at least 1.0.0

### DIFF
--- a/rfcs/0014-use-production-versions-for-scripts.md
+++ b/rfcs/0014-use-production-versions-for-scripts.md
@@ -1,22 +1,22 @@
-# RFC 14 - Use production versions for scripts
+# RFC 14 - Use production semver versions for releng packages
 * Comments: [#14](https://api.github.com/repos/mozilla-releng/releng-rfcs/issues/14)
 * Proposed by: @mitchhentges, on behalf of discussion [in bug 1524248](https://bugzilla.mozilla.org/show_bug.cgi?id=1524248) 
 
 # Summary
 
-Bump all script versions to >= `1.0.0`.
+Bump all releng library and *script versions to >= `1.0.0`.
 
 ## Motivation
 
-We're using our *scripts in production. According to [semver.org](https://semver.org/#how-do-i-know-when-to-release-100),
+We're using our packages in production. According to [semver.org](https://semver.org/#how-do-i-know-when-to-release-100),
 if software is being used in production, it should be >= `1.0.0`.
 
-This will also allow us to convey intention in versions better (patches, deprecations, etc).
+This will also allow us to convey intention in versions better (patches, deprecations, breaking changes, etc).
 
 # Details
 
-Bump all script versions to `1.0.0` (for those that aren't >= `1.0.0` already).
-Follow [semver](https://semver.org/)
+Bump all releng package versions to `1.0.0` (for those that aren't >= `1.0.0` already).
+Follow [semver](https://semver.org/).
 
 # Open Questions
 

--- a/rfcs/0014-use-production-versions-for-scripts.md
+++ b/rfcs/0014-use-production-versions-for-scripts.md
@@ -1,21 +1,21 @@
-# RFC 14 - Use production semver versions for releng packages
+# RFC 14 - Use production semver versions for production releng packages
 * Comments: [#14](https://api.github.com/repos/mozilla-releng/releng-rfcs/issues/14)
 * Proposed by: @mitchhentges, on behalf of discussion [in bug 1524248](https://bugzilla.mozilla.org/show_bug.cgi?id=1524248) 
 
 # Summary
 
-Bump all releng library and *script versions to >= `1.0.0`.
+Bump all production releng library and *script versions to >= `1.0.0`.
 
 ## Motivation
 
-We're using our packages in production. According to [semver.org](https://semver.org/#how-do-i-know-when-to-release-100),
+We're using some of our packages in production. According to [semver.org](https://semver.org/#how-do-i-know-when-to-release-100),
 if software is being used in production, it should be >= `1.0.0`.
 
 This will also allow us to convey intention in versions better (patches, deprecations, breaking changes, etc).
 
 # Details
 
-Bump all releng package versions to `1.0.0` (for those that aren't >= `1.0.0` already).
+For all of our releng packages that we use in production, bump their versions to `1.0.0` (for those that aren't >= `1.0.0` already).
 Follow [semver](https://semver.org/).
 
 # Open Questions

--- a/rfcs/0014-use-production-versions-for-scripts.md
+++ b/rfcs/0014-use-production-versions-for-scripts.md
@@ -17,6 +17,8 @@ This will also allow us to convey intention in versions better (patches, depreca
 
 For all of our releng packages that we use in production, bump their versions to `1.0.0` (for those that aren't >= `1.0.0` already).
 Follow [semver](https://semver.org/).
+Importantly, this means that a backwards-incompatible change to _any_ public-facing functionality (e.g.: *script config 
+or task payload structure) must be followed by a major version bump.
 
 # Open Questions
 

--- a/rfcs/0014-use-production-versions-for-scripts.md
+++ b/rfcs/0014-use-production-versions-for-scripts.md
@@ -23,3 +23,5 @@ or task payload structure) must be followed by a major version bump.
 # Open Questions
 
 # Implementation
+
+* [Tracking bug](https://github.com/mozilla-releng/releng-rfcs/issues/19)

--- a/rfcs/0014-use-production-versions-for-scripts.md
+++ b/rfcs/0014-use-production-versions-for-scripts.md
@@ -1,5 +1,5 @@
-# RFC <number> - Use production versions for scripts
-* Comments: [#<number>](https://api.github.com/repos/mozilla-releng/releng-rfcs/issues/<number>)
+# RFC 14 - Use production versions for scripts
+* Comments: [#14](https://api.github.com/repos/mozilla-releng/releng-rfcs/issues/14)
 * Proposed by: @mitchhentges, on behalf of discussion [in bug 1524248](https://bugzilla.mozilla.org/show_bug.cgi?id=1524248) 
 
 # Summary

--- a/rfcs/xxxx-use-production-versions-for-scripts.md
+++ b/rfcs/xxxx-use-production-versions-for-scripts.md
@@ -1,0 +1,23 @@
+# RFC <number> - Use production versions for scripts
+* Comments: [#<number>](https://api.github.com/repos/mozilla-releng/releng-rfcs/issues/<number>)
+* Proposed by: @mitchhentges, on behalf of discussion [in bug 1524248](https://bugzilla.mozilla.org/show_bug.cgi?id=1524248) 
+
+# Summary
+
+Bump all script versions to >= `1.0.0`.
+
+## Motivation
+
+We're using our *scripts in production. According to [semver.org](https://semver.org/#how-do-i-know-when-to-release-100),
+if software is being used in production, it should be >= `1.0.0`.
+
+This will also allow us to convey intention in versions better (patches, deprecations, etc).
+
+# Details
+
+Bump all script versions to `1.0.0` (for those that aren't >= `1.0.0` already).
+Follow [semver](https://semver.org/)
+
+# Open Questions
+
+# Implementation


### PR DESCRIPTION
[rendered](https://github.com/mitchhentges/releng-rfcs/blob/script-versions-1.0.0-production/rfcs/0014-use-production-versions-for-scripts.md).
Based on the discussion from [here](https://bugzilla.mozilla.org/show_bug.cgi?id=1524248)